### PR TITLE
Fix: 主界面版本号在个别设备上显示不全的问题

### DIFF
--- a/src/icu/minesweeper/ui/MenuPane.java
+++ b/src/icu/minesweeper/ui/MenuPane.java
@@ -33,7 +33,11 @@ public class MenuPane extends AutoResizePane {
 		titleLabel.setSize(titleLabel.getPreferredSize());
 		titleLabel.setLocation(0, 0);
 		versionLabel.setFont(new Font("微软雅黑", Font.PLAIN, 18));
-		versionLabel.setSize(versionLabel.getPreferredSize());
+		Dimension versionLabelDimension = versionLabel.getPreferredSize();
+		versionLabel.setSize(
+			versionLabelDimension.width + 5,
+			versionLabelDimension.height
+		);
 		versionLabel.setLocation(titleLabel.getWidth(), titleLabel.getHeight() - versionLabel.getHeight());
 		titlePanel.setSize(titleLabel.getWidth() + versionLabel.getWidth(), titleLabel.getHeight() + versionLabel.getHeight());
 		actionPanel = new JPanel();


### PR DESCRIPTION
我的设备上版本号会显示不全，所以尝试让宽度增加了 5px （貌似解决了？）